### PR TITLE
feat: add originBundleId field for version ordering

### DIFF
--- a/packages/console/src/routes/_components/promote-channel-dialog.tsx
+++ b/packages/console/src/routes/_components/promote-channel-dialog.tsx
@@ -53,10 +53,12 @@ export const PromoteChannelDialog = ({ bundle }: PromoteChannelDialogProps) => {
     try {
       if (shouldCopy()) {
         // Copy: Create new bundle with new ID (preserving timestamp) and target channel
+        // Propagate originBundleId so the server can detect bundle equivalence
         const newBundle: Bundle = {
           ...bundle,
           id: createUUIDv7WithSameTimestamp(bundle.id),
           channel: selectedChannel(),
+          originBundleId: bundle.originBundleId,
         };
 
         const res = await api.bundles.$post({

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -65,6 +65,12 @@ export interface Bundle {
    * The metadata of the bundle.
    */
   metadata?: BundleMetadata;
+  /**
+   * The original bundle ID that owns the physical storage resource.
+   * For directly deployed bundles, this equals the bundle's own `id`.
+   * For copy-promoted bundles, this is propagated from the source bundle.
+   */
+  originBundleId: string;
 }
 
 type SnakeCase<S extends string> = S extends `${infer T}${infer U}`

--- a/packages/hot-updater/src/commands/deploy.ts
+++ b/packages/hot-updater/src/commands/deploy.ts
@@ -418,6 +418,7 @@ export const deploy = async (options: DeployOptions) => {
               targetAppVersion: target.appVersion,
               fingerprintHash: target.fingerprintHash,
               storageUri: taskRef.storageUri,
+              originBundleId: bundleId,
               metadata: {
                 ...(appVersion
                   ? {

--- a/packages/server/src/db/index.spec.ts
+++ b/packages/server/src/db/index.spec.ts
@@ -92,6 +92,7 @@ describe("server/db hotUpdater getUpdateInfo (PGlite + Kysely)", async () => {
     it("should retrieve bundle by id without Prisma validation errors", async () => {
       const bundle: Bundle = {
         id: "00000000-0000-0000-0000-000000000010",
+        originBundleId: "00000000-0000-0000-0000-000000000010",
         platform: "ios",
         shouldForceUpdate: false,
         enabled: true,
@@ -129,6 +130,7 @@ describe("server/db hotUpdater getUpdateInfo (PGlite + Kysely)", async () => {
       const bundles: Bundle[] = [
         {
           id: "00000000-0000-0000-0000-000000000020",
+          originBundleId: "00000000-0000-0000-0000-000000000020",
           platform: "ios",
           shouldForceUpdate: false,
           enabled: true,
@@ -142,6 +144,7 @@ describe("server/db hotUpdater getUpdateInfo (PGlite + Kysely)", async () => {
         },
         {
           id: "00000000-0000-0000-0000-000000000021",
+          originBundleId: "00000000-0000-0000-0000-000000000021",
           platform: "android",
           shouldForceUpdate: false,
           enabled: true,
@@ -155,6 +158,7 @@ describe("server/db hotUpdater getUpdateInfo (PGlite + Kysely)", async () => {
         },
         {
           id: "00000000-0000-0000-0000-000000000022",
+          originBundleId: "00000000-0000-0000-0000-000000000022",
           platform: "ios",
           shouldForceUpdate: false,
           enabled: true,
@@ -200,6 +204,7 @@ describe("server/db hotUpdater getUpdateInfo (PGlite + Kysely)", async () => {
     it("resolves s3:// storage URI to signed URL via s3StoragePlugin", async () => {
       const bundle: Bundle = {
         id: "00000000-0000-0000-0000-000000000001",
+        originBundleId: "00000000-0000-0000-0000-000000000001",
         platform: "ios",
         shouldForceUpdate: false,
         enabled: true,
@@ -230,6 +235,7 @@ describe("server/db hotUpdater getUpdateInfo (PGlite + Kysely)", async () => {
     it("passes through http:// URLs without plugin resolution", async () => {
       const bundle: Bundle = {
         id: "00000000-0000-0000-0000-000000000004",
+        originBundleId: "00000000-0000-0000-0000-000000000004",
         platform: "ios",
         shouldForceUpdate: false,
         enabled: true,
@@ -260,6 +266,7 @@ describe("server/db hotUpdater getUpdateInfo (PGlite + Kysely)", async () => {
     it("passes through https:// URLs without plugin resolution", async () => {
       const bundle: Bundle = {
         id: "00000000-0000-0000-0000-000000000005",
+        originBundleId: "00000000-0000-0000-0000-000000000005",
         platform: "ios",
         shouldForceUpdate: false,
         enabled: true,
@@ -299,6 +306,7 @@ describe("server/db hotUpdater getUpdateInfo (PGlite + Kysely)", async () => {
     it("works with fingerprint strategy", async () => {
       const bundle: Bundle = {
         id: "00000000-0000-0000-0000-000000000008",
+        originBundleId: "00000000-0000-0000-0000-000000000008",
         platform: "ios",
         shouldForceUpdate: false,
         enabled: true,

--- a/packages/server/src/db/ormCore.ts
+++ b/packages/server/src/db/ormCore.ts
@@ -14,12 +14,13 @@ import { fumadb } from "fumadb";
 import type { FumaDBAdapter } from "fumadb/adapters";
 import { calculatePagination } from "../calculatePagination";
 import { v0_21_0 } from "../schema/v0_21_0";
+import { v0_27_0 } from "../schema/v0_27_0";
 import type { PaginationInfo } from "../types";
 import type { DatabaseAPI } from "./types";
 
 export const HotUpdaterDB = fumadb({
   namespace: "hot_updater",
-  schemas: [v0_21_0],
+  schemas: [v0_21_0, v0_27_0],
 });
 
 export type HotUpdaterClient = InferFumaDB<typeof HotUpdaterDB>;
@@ -74,6 +75,8 @@ export function createOrmDatabaseCore({
         storageUri: result.storage_uri,
         targetAppVersion: result.target_app_version ?? null,
         fingerprintHash: result.fingerprint_hash ?? null,
+        // `as any` needed for backward compat with schemas before v0_27_0
+        originBundleId: (result as any).origin_bundle_id || result.id,
       };
       return bundle;
     },
@@ -111,6 +114,10 @@ export function createOrmDatabaseCore({
         storageUri: null,
         fileHash: null,
       };
+
+      // Helper to extract originBundleId from a row (backward compat with schemas before v0_27_0)
+      const getOriginBundleId = (row: { id: string }): string =>
+        (row as any).origin_bundle_id || row.id;
 
       const appVersionStrategy = async ({
         platform,
@@ -159,25 +166,37 @@ export function createOrmDatabaseCore({
                   ),
               });
 
-        const candidates = (baseRows ?? []).filter((r) =>
-          r.target_app_version
-            ? compatibleVersions.includes(r.target_app_version)
-            : false,
+        // Filter by compatible versions and originBundleId >= minBundleId
+        const candidates = (baseRows ?? []).filter(
+          (r) =>
+            r.target_app_version &&
+            compatibleVersions.includes(r.target_app_version) &&
+            getOriginBundleId(r).localeCompare(minBundleId) >= 0,
         );
 
-        const byIdDesc = (a: { id: string }, b: { id: string }) =>
-          b.id.localeCompare(a.id);
-        const sorted = (candidates ?? []).slice().sort(byIdDesc);
+        // Sort by originBundleId descending for version ordering
+        const byOriginDesc = (a: { id: string }, b: { id: string }) =>
+          getOriginBundleId(b).localeCompare(getOriginBundleId(a));
+        const sorted = (candidates ?? []).slice().sort(byOriginDesc);
 
         const latestCandidate = sorted[0] ?? null;
-        const currentBundle = sorted.find((b) => b.id === bundleId);
+        const currentBundle = sorted.find(
+          (b) => getOriginBundleId(b) === bundleId,
+        );
         const updateCandidate =
-          sorted.find((b) => b.id.localeCompare(bundleId) > 0) ?? null;
+          sorted.find(
+            (b) => getOriginBundleId(b).localeCompare(bundleId) > 0,
+          ) ?? null;
         const rollbackCandidate =
-          sorted.find((b) => b.id.localeCompare(bundleId) < 0) ?? null;
+          sorted.find(
+            (b) => getOriginBundleId(b).localeCompare(bundleId) < 0,
+          ) ?? null;
 
         if (bundleId === NIL_UUID) {
-          if (latestCandidate && latestCandidate.id !== bundleId) {
+          if (
+            latestCandidate &&
+            getOriginBundleId(latestCandidate) !== bundleId
+          ) {
             return toUpdateInfo(latestCandidate, "UPDATE");
           }
           return null;
@@ -186,7 +205,9 @@ export function createOrmDatabaseCore({
         if (currentBundle) {
           if (
             latestCandidate &&
-            latestCandidate.id.localeCompare(currentBundle.id) > 0
+            getOriginBundleId(latestCandidate).localeCompare(
+              getOriginBundleId(currentBundle),
+            ) > 0
           ) {
             return toUpdateInfo(latestCandidate, "UPDATE");
           }
@@ -213,7 +234,7 @@ export function createOrmDatabaseCore({
         minBundleId = NIL_UUID,
         channel = "production",
       }: FingerprintGetBundlesArgs): Promise<UpdateInfo | null> => {
-        const candidates = await orm.findMany("bundles", {
+        const rawCandidates = await orm.findMany("bundles", {
           select: [
             "id",
             "should_force_update",
@@ -234,19 +255,34 @@ export function createOrmDatabaseCore({
             ),
         });
 
-        const byIdDesc = (a: { id: string }, b: { id: string }) =>
-          b.id.localeCompare(a.id);
-        const sorted = (candidates ?? []).slice().sort(byIdDesc);
+        // Post-filter by originBundleId >= minBundleId
+        const candidates = (rawCandidates ?? []).filter(
+          (r) => getOriginBundleId(r).localeCompare(minBundleId) >= 0,
+        );
+
+        // Sort by originBundleId descending for version ordering
+        const byOriginDesc = (a: { id: string }, b: { id: string }) =>
+          getOriginBundleId(b).localeCompare(getOriginBundleId(a));
+        const sorted = (candidates ?? []).slice().sort(byOriginDesc);
 
         const latestCandidate = sorted[0] ?? null;
-        const currentBundle = sorted.find((b) => b.id === bundleId);
+        const currentBundle = sorted.find(
+          (b) => getOriginBundleId(b) === bundleId,
+        );
         const updateCandidate =
-          sorted.find((b) => b.id.localeCompare(bundleId) > 0) ?? null;
+          sorted.find(
+            (b) => getOriginBundleId(b).localeCompare(bundleId) > 0,
+          ) ?? null;
         const rollbackCandidate =
-          sorted.find((b) => b.id.localeCompare(bundleId) < 0) ?? null;
+          sorted.find(
+            (b) => getOriginBundleId(b).localeCompare(bundleId) < 0,
+          ) ?? null;
 
         if (bundleId === NIL_UUID) {
-          if (latestCandidate && latestCandidate.id !== bundleId) {
+          if (
+            latestCandidate &&
+            getOriginBundleId(latestCandidate) !== bundleId
+          ) {
             return toUpdateInfo(latestCandidate, "UPDATE");
           }
           return null;
@@ -255,7 +291,9 @@ export function createOrmDatabaseCore({
         if (currentBundle) {
           if (
             latestCandidate &&
-            latestCandidate.id.localeCompare(currentBundle.id) > 0
+            getOriginBundleId(latestCandidate).localeCompare(
+              getOriginBundleId(currentBundle),
+            ) > 0
           ) {
             return toUpdateInfo(latestCandidate, "UPDATE");
           }
@@ -356,6 +394,8 @@ export function createOrmDatabaseCore({
             storageUri: r.storage_uri,
             targetAppVersion: r.target_app_version ?? null,
             fingerprintHash: r.fingerprint_hash ?? null,
+            // `as any` needed for backward compat with schemas before v0_27_0
+            originBundleId: (r as any).origin_bundle_id || r.id,
           }),
         )
         .sort((a, b) => b.id.localeCompare(a.id));
@@ -385,6 +425,7 @@ export function createOrmDatabaseCore({
         target_app_version: bundle.targetAppVersion,
         fingerprint_hash: bundle.fingerprintHash,
         metadata: bundle.metadata ?? {},
+        origin_bundle_id: bundle.originBundleId || bundle.id,
       };
       const { id, ...updateValues } = values;
       await orm.upsert("bundles", {
@@ -416,6 +457,7 @@ export function createOrmDatabaseCore({
         target_app_version: merged.targetAppVersion,
         fingerprint_hash: merged.fingerprintHash,
         metadata: merged.metadata ?? {},
+        origin_bundle_id: merged.originBundleId || merged.id,
       };
       const { id: id2, ...updateValues2 } = values;
       await orm.upsert("bundles", {

--- a/packages/server/src/handler-standalone-integration.spec.ts
+++ b/packages/server/src/handler-standalone-integration.spec.ts
@@ -90,6 +90,7 @@ afterAll(async () => {
 
 const createTestBundle = (overrides?: Partial<Bundle>): Bundle => ({
   id: NIL_UUID,
+  originBundleId: NIL_UUID,
   platform: "ios",
   channel: "production",
   enabled: true,

--- a/packages/server/src/schema/v0_27_0.ts
+++ b/packages/server/src/schema/v0_27_0.ts
@@ -1,0 +1,23 @@
+import { column, idColumn, schema, table } from "fumadb/schema";
+
+export const v0_27_0 = schema({
+  version: "0.27.0",
+  tables: {
+    bundles: table("bundles", {
+      id: idColumn("id", "uuid"),
+      platform: column("platform", "string"),
+      should_force_update: column("should_force_update", "bool"),
+      enabled: column("enabled", "bool"),
+      file_hash: column("file_hash", "string"),
+      git_commit_hash: column("git_commit_hash", "string").nullable(),
+      message: column("message", "string").nullable(),
+      channel: column("channel", "string"),
+      storage_uri: column("storage_uri", "string"),
+      target_app_version: column("target_app_version", "string").nullable(),
+      fingerprint_hash: column("fingerprint_hash", "string").nullable(),
+      metadata: column("metadata", "json"),
+      origin_bundle_id: column("origin_bundle_id", "string"),
+    }),
+  },
+  relations: {},
+});

--- a/packages/test-utils/src/setupBundleMethodsTestSuite.ts
+++ b/packages/test-utils/src/setupBundleMethodsTestSuite.ts
@@ -46,6 +46,7 @@ export const setupBundleMethodsTestSuite = ({
         targetAppVersion: "1.0.0",
         fingerprintHash: null,
         metadata: {},
+        originBundleId: "00000000-0000-0000-0000-000000000010",
       };
 
       await insertBundle(bundle);
@@ -83,6 +84,7 @@ export const setupBundleMethodsTestSuite = ({
           storageUri: "mock://test/1.zip",
           targetAppVersion: "1.0.0",
           fingerprintHash: null,
+          originBundleId: "00000000-0000-0000-0000-000000000020",
         },
         {
           id: "00000000-0000-0000-0000-000000000021",
@@ -96,6 +98,7 @@ export const setupBundleMethodsTestSuite = ({
           storageUri: "mock://test/2.zip",
           targetAppVersion: "1.0.0",
           fingerprintHash: null,
+          originBundleId: "00000000-0000-0000-0000-000000000021",
         },
         {
           id: "00000000-0000-0000-0000-000000000022",
@@ -109,6 +112,7 @@ export const setupBundleMethodsTestSuite = ({
           storageUri: "mock://test/3.zip",
           targetAppVersion: "1.0.0",
           fingerprintHash: null,
+          originBundleId: "00000000-0000-0000-0000-000000000022",
         },
       ];
 
@@ -140,6 +144,7 @@ export const setupBundleMethodsTestSuite = ({
           storageUri: "mock://test/1.zip",
           targetAppVersion: "1.0.0",
           fingerprintHash: null,
+          originBundleId: "00000000-0000-0000-0000-000000000030",
         },
         {
           id: "00000000-0000-0000-0000-000000000031",
@@ -153,6 +158,7 @@ export const setupBundleMethodsTestSuite = ({
           storageUri: "mock://test/2.zip",
           targetAppVersion: "1.0.0",
           fingerprintHash: null,
+          originBundleId: "00000000-0000-0000-0000-000000000031",
         },
       ];
 
@@ -185,6 +191,7 @@ export const setupBundleMethodsTestSuite = ({
           storageUri: "mock://test/3.zip",
           targetAppVersion: "1.0.0",
           fingerprintHash: null,
+          originBundleId: "00000000-0000-0000-0000-000000000032",
         },
         {
           id: "00000000-0000-0000-0000-000000000033",
@@ -198,6 +205,7 @@ export const setupBundleMethodsTestSuite = ({
           storageUri: "mock://test/4.zip",
           targetAppVersion: "1.0.0",
           fingerprintHash: null,
+          originBundleId: "00000000-0000-0000-0000-000000000033",
         },
       ];
 
@@ -231,6 +239,7 @@ export const setupBundleMethodsTestSuite = ({
           storageUri: "mock://test/5.zip",
           targetAppVersion: "1.0.0",
           fingerprintHash: null,
+          originBundleId: "00000000-0000-0000-0000-000000000034",
         },
         {
           id: "00000000-0000-0000-0000-000000000035",
@@ -244,6 +253,7 @@ export const setupBundleMethodsTestSuite = ({
           storageUri: "mock://test/6.zip",
           targetAppVersion: "1.0.0",
           fingerprintHash: null,
+          originBundleId: "00000000-0000-0000-0000-000000000035",
         },
       ];
 
@@ -277,6 +287,7 @@ export const setupBundleMethodsTestSuite = ({
           storageUri: "mock://test/7.zip",
           targetAppVersion: "1.0.0",
           fingerprintHash: null,
+          originBundleId: "00000000-0000-0000-0000-000000000036",
         },
         {
           id: "00000000-0000-0000-0000-000000000037",
@@ -290,6 +301,7 @@ export const setupBundleMethodsTestSuite = ({
           storageUri: "mock://test/8.zip",
           targetAppVersion: "1.0.0",
           fingerprintHash: null,
+          originBundleId: "00000000-0000-0000-0000-000000000037",
         },
       ];
 
@@ -349,6 +361,7 @@ export const setupBundleMethodsTestSuite = ({
         storageUri: "mock://test/update.zip",
         targetAppVersion: "1.0.0",
         fingerprintHash: null,
+        originBundleId: "00000000-0000-0000-0000-000000000040",
       };
 
       await insertBundle(bundle);
@@ -374,6 +387,7 @@ export const setupBundleMethodsTestSuite = ({
         storageUri: "mock://test/message.zip",
         targetAppVersion: "1.0.0",
         fingerprintHash: null,
+        originBundleId: "00000000-0000-0000-0000-000000000041",
       };
 
       await insertBundle(bundle);
@@ -399,6 +413,7 @@ export const setupBundleMethodsTestSuite = ({
         storageUri: "mock://test/multi.zip",
         targetAppVersion: "1.0.0",
         fingerprintHash: null,
+        originBundleId: "00000000-0000-0000-0000-000000000042",
       };
 
       await insertBundle(bundle);
@@ -431,6 +446,7 @@ export const setupBundleMethodsTestSuite = ({
         storageUri: "mock://test/delete.zip",
         targetAppVersion: "1.0.0",
         fingerprintHash: null,
+        originBundleId: "00000000-0000-0000-0000-000000000050",
       };
 
       await insertBundle(bundle);

--- a/packages/test-utils/src/setupGetUpdateInfoTestSuite.ts
+++ b/packages/test-utils/src/setupGetUpdateInfoTestSuite.ts
@@ -51,6 +51,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -88,6 +89,7 @@ export const setupGetUpdateInfoTestSuite = ({
           targetAppVersion: "1.1",
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
           shouldForceUpdate: false,
         },
       ];
@@ -108,6 +110,7 @@ export const setupGetUpdateInfoTestSuite = ({
           targetAppVersion: "1.0.0",
           enabled: true,
           id: "01963024-c131-7971-8725-ab47e232df41",
+          originBundleId: "01963024-c131-7971-8725-ab47e232df41",
           shouldForceUpdate: false,
         },
         {
@@ -115,6 +118,7 @@ export const setupGetUpdateInfoTestSuite = ({
           targetAppVersion: "1.0.1",
           enabled: true,
           id: "01963024-c131-7971-8725-ab47e232df42",
+          originBundleId: "01963024-c131-7971-8725-ab47e232df42",
           shouldForceUpdate: false,
         },
       ];
@@ -135,6 +139,7 @@ export const setupGetUpdateInfoTestSuite = ({
           targetAppVersion: "1.x.x",
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
           shouldForceUpdate: false,
         },
         {
@@ -142,6 +147,7 @@ export const setupGetUpdateInfoTestSuite = ({
           targetAppVersion: "1.0",
           enabled: true,
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
           shouldForceUpdate: false,
         },
       ];
@@ -167,6 +173,7 @@ export const setupGetUpdateInfoTestSuite = ({
           targetAppVersion: "1.0",
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
           shouldForceUpdate: true,
         },
       ];
@@ -192,6 +199,7 @@ export const setupGetUpdateInfoTestSuite = ({
           targetAppVersion: "1.0",
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
           shouldForceUpdate: false,
         },
       ];
@@ -218,6 +226,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000005",
+          originBundleId: "00000000-0000-0000-0000-000000000005",
         },
       ];
 
@@ -243,6 +252,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: true,
           enabled: false, // Disabled
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -250,6 +260,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -275,6 +286,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: true,
           enabled: false, // Disabled
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -282,6 +294,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: false, // Disabled
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -302,6 +315,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: true,
           enabled: false, // Disabled
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -309,6 +323,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: false, // Disabled
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -331,6 +346,7 @@ export const setupGetUpdateInfoTestSuite = ({
           message: "hi",
           targetAppVersion: "1.0",
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
           enabled: true,
         },
       ];
@@ -369,6 +385,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -376,6 +393,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -396,6 +414,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -421,6 +440,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000003",
+          originBundleId: "00000000-0000-0000-0000-000000000003",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -428,6 +448,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -435,6 +456,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -460,6 +482,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000005", // Higher than the current version
+          originBundleId: "00000000-0000-0000-0000-000000000005",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -467,6 +490,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000004",
+          originBundleId: "00000000-0000-0000-0000-000000000004",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -475,6 +499,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000003",
+          originBundleId: "00000000-0000-0000-0000-000000000003",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -482,6 +507,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -489,6 +515,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -514,6 +541,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: true,
           enabled: false, // Disabled
           id: "00000000-0000-0000-0000-000000000003",
+          originBundleId: "00000000-0000-0000-0000-000000000003",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -521,6 +549,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: true,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -528,6 +557,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -548,6 +578,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: true,
           enabled: false, // Disabled
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -555,6 +586,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -581,6 +613,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: true,
           enabled: false, // Disabled
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -588,6 +621,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: false, // Disabled
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -608,6 +642,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "0195715a-ce29-7c55-97d3-53af4fe369b7", // 2025-03-07T16:05:31.305Z
+          originBundleId: "0195715a-ce29-7c55-97d3-53af4fe369b7",
         },
       ];
 
@@ -629,6 +664,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "0195715d-42db-7475-9204-31819efc2f1d", // 2025-03-07T16:08:12.251Z
+          originBundleId: "0195715d-42db-7475-9204-31819efc2f1d",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -636,6 +672,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "0195715a-ce29-7c55-97d3-53af4fe369b7", // 2025-03-07T16:05:31.305Z
+          originBundleId: "0195715a-ce29-7c55-97d3-53af4fe369b7",
         },
       ];
 
@@ -662,6 +699,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: false, // disabled
           id: "0195715d-42db-7475-9204-31819efc2f1d", // 2025-03-07T16:08:12.251Z
+          originBundleId: "0195715d-42db-7475-9204-31819efc2f1d",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -669,6 +707,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "0195715a-ce29-7c55-97d3-53af4fe369b7", // 2025-03-07T16:05:31.305Z
+          originBundleId: "0195715a-ce29-7c55-97d3-53af4fe369b7",
         },
       ];
 
@@ -690,6 +729,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "0195715a-ce29-7c55-97d3-53af4fe369b7", // 2025-03-07T16:05:31.305Z
+          originBundleId: "0195715a-ce29-7c55-97d3-53af4fe369b7",
         },
       ];
 
@@ -711,6 +751,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true, // disabled
           id: "0195715d-42db-7475-9204-31819efc2f1d", // 2025-03-07T16:08:12.251Z
+          originBundleId: "0195715d-42db-7475-9204-31819efc2f1d",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -718,6 +759,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "0195715a-ce29-7c55-97d3-53af4fe369b7", // 2025-03-07T16:05:31.305Z
+          originBundleId: "0195715a-ce29-7c55-97d3-53af4fe369b7",
         },
       ];
 
@@ -739,6 +781,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "01957165-bee7-7df3-a25d-6686f01b02ba", //2025-03-07T16:17:28.295Z
+          originBundleId: "01957165-bee7-7df3-a25d-6686f01b02ba",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -746,6 +789,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "01957165-19fb-75af-a361-131c17a65ef2", // 2025-03-07T16:16:46.075Z
+          originBundleId: "01957165-19fb-75af-a361-131c17a65ef2",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -753,6 +797,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "01957164-fbc6-785f-98ce-a6ae459f6e4f", // 2025-03-07T16:16:38.342Z
+          originBundleId: "01957164-fbc6-785f-98ce-a6ae459f6e4f",
         },
       ];
 
@@ -774,6 +819,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "0195716c-82f5-7e5e-ac8c-d4fbf5bc7555", // 2025-03-07T16:24:51.701Z
+          originBundleId: "0195716c-82f5-7e5e-ac8c-d4fbf5bc7555",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -781,6 +827,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "01957167-0389-7064-8d86-f8af7950daed", // 2025-03-07T16:18:51.401Z
+          originBundleId: "01957167-0389-7064-8d86-f8af7950daed",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -788,6 +835,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "01957165-bee7-7df3-a25d-6686f01b02ba", //2025-03-07T16:17:28.295Z
+          originBundleId: "01957165-bee7-7df3-a25d-6686f01b02ba",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -795,6 +843,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "01957165-19fb-75af-a361-131c17a65ef2", // 2025-03-07T16:16:46.075Z
+          originBundleId: "01957165-19fb-75af-a361-131c17a65ef2",
         },
         {
           ...DEFAULT_BUNDLE_APP_VERSION_STRATEGY,
@@ -802,6 +851,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "01957164-fbc6-785f-98ce-a6ae459f6e4f", // 2025-03-07T16:16:38.342Z
+          originBundleId: "01957164-fbc6-785f-98ce-a6ae459f6e4f",
         },
       ];
 
@@ -828,6 +878,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "01957179-d99d-7fbb-bc1e-feff6b3236f0", // only available bundle, equal to minBundleId
+          originBundleId: "01957179-d99d-7fbb-bc1e-feff6b3236f0",
         },
       ];
 
@@ -850,6 +901,7 @@ export const setupGetUpdateInfoTestSuite = ({
           enabled: true,
           channel: "beta",
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -873,6 +925,7 @@ export const setupGetUpdateInfoTestSuite = ({
           enabled: true,
           channel: "beta",
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -900,6 +953,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           targetAppVersion: "1.0",
           id: "01957b63-7d11-7281-b8e7-1120ccfdb8ab",
+          originBundleId: "01957b63-7d11-7281-b8e7-1120ccfdb8ab",
         },
       ];
 
@@ -937,6 +991,7 @@ export const setupGetUpdateInfoTestSuite = ({
           enabled: true,
           shouldForceUpdate: true,
           id: "01963024-c131-7971-8725-ab47e232df40",
+          originBundleId: "01963024-c131-7971-8725-ab47e232df40",
           platform: "ios",
           targetAppVersion: "1.0.0",
         },
@@ -966,6 +1021,7 @@ export const setupGetUpdateInfoTestSuite = ({
           targetAppVersion: ">= 5.7.0 <= 5.7.4",
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
           shouldForceUpdate: false,
         },
       ];
@@ -992,6 +1048,7 @@ export const setupGetUpdateInfoTestSuite = ({
           targetAppVersion: ">= 5.7.0 <= 5.7.4",
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
           shouldForceUpdate: false,
         },
       ];
@@ -1027,6 +1084,7 @@ export const setupGetUpdateInfoTestSuite = ({
           fingerprintHash: "hash2",
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
           shouldForceUpdate: false,
         },
       ];
@@ -1047,6 +1105,7 @@ export const setupGetUpdateInfoTestSuite = ({
           fingerprintHash: "hash1",
           enabled: true,
           id: "01963024-c131-7971-8725-ab47e232df41",
+          originBundleId: "01963024-c131-7971-8725-ab47e232df41",
           shouldForceUpdate: false,
         },
         {
@@ -1054,6 +1113,7 @@ export const setupGetUpdateInfoTestSuite = ({
           fingerprintHash: "hash2",
           enabled: true,
           id: "01963024-c131-7971-8725-ab47e232df42",
+          originBundleId: "01963024-c131-7971-8725-ab47e232df42",
           shouldForceUpdate: false,
         },
       ];
@@ -1074,6 +1134,7 @@ export const setupGetUpdateInfoTestSuite = ({
           fingerprintHash: "hash1",
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
           shouldForceUpdate: false,
         },
         {
@@ -1081,6 +1142,7 @@ export const setupGetUpdateInfoTestSuite = ({
           fingerprintHash: "hash2",
           enabled: true,
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
           shouldForceUpdate: false,
         },
       ];
@@ -1106,6 +1168,7 @@ export const setupGetUpdateInfoTestSuite = ({
           fingerprintHash: "hash1",
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
           shouldForceUpdate: true,
         },
       ];
@@ -1131,6 +1194,7 @@ export const setupGetUpdateInfoTestSuite = ({
           fingerprintHash: "hash1",
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
           shouldForceUpdate: false,
         },
       ];
@@ -1157,6 +1221,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000005",
+          originBundleId: "00000000-0000-0000-0000-000000000005",
         },
       ];
 
@@ -1182,6 +1247,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: true,
           enabled: false, // Disabled
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1189,6 +1255,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -1214,6 +1281,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: true,
           enabled: false, // Disabled
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1221,6 +1289,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: false, // Disabled
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -1241,6 +1310,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: true,
           enabled: false, // Disabled
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1248,6 +1318,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: false, // Disabled
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -1270,6 +1341,7 @@ export const setupGetUpdateInfoTestSuite = ({
           message: "hi",
           fingerprintHash: "hash1",
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
           enabled: true,
         },
       ];
@@ -1308,6 +1380,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1315,6 +1388,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -1335,6 +1409,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -1360,6 +1435,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000003",
+          originBundleId: "00000000-0000-0000-0000-000000000003",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1367,6 +1443,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1374,6 +1451,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -1399,6 +1477,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000005", // Higher than the current version
+          originBundleId: "00000000-0000-0000-0000-000000000005",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1406,6 +1485,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000004",
+          originBundleId: "00000000-0000-0000-0000-000000000004",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1413,6 +1493,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000003",
+          originBundleId: "00000000-0000-0000-0000-000000000003",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1420,6 +1501,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1427,6 +1509,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -1452,6 +1535,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: true,
           enabled: false, // Disabled
           id: "00000000-0000-0000-0000-000000000003",
+          originBundleId: "00000000-0000-0000-0000-000000000003",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1459,6 +1543,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: true,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1466,6 +1551,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -1486,6 +1572,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: true,
           enabled: false, // Disabled
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1493,6 +1580,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -1519,6 +1607,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: true,
           enabled: false, // Disabled
           id: "00000000-0000-0000-0000-000000000002",
+          originBundleId: "00000000-0000-0000-0000-000000000002",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1526,6 +1615,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: false, // Disabled
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -1546,6 +1636,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "0195715a-ce29-7c55-97d3-53af4fe369b7", // 2025-03-07T16:05:31.305Z
+          originBundleId: "0195715a-ce29-7c55-97d3-53af4fe369b7",
         },
       ];
 
@@ -1567,6 +1658,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "0195715d-42db-7475-9204-31819efc2f1d", // 2025-03-07T16:08:12.251Z
+          originBundleId: "0195715d-42db-7475-9204-31819efc2f1d",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1574,6 +1666,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "0195715a-ce29-7c55-97d3-53af4fe369b7", // 2025-03-07T16:05:31.305Z
+          originBundleId: "0195715a-ce29-7c55-97d3-53af4fe369b7",
         },
       ];
 
@@ -1600,6 +1693,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: false, // disabled
           id: "0195715d-42db-7475-9204-31819efc2f1d", // 2025-03-07T16:08:12.251Z
+          originBundleId: "0195715d-42db-7475-9204-31819efc2f1d",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1607,6 +1701,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "0195715a-ce29-7c55-97d3-53af4fe369b7", // 2025-03-07T16:05:31.305Z
+          originBundleId: "0195715a-ce29-7c55-97d3-53af4fe369b7",
         },
       ];
 
@@ -1628,6 +1723,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "0195715a-ce29-7c55-97d3-53af4fe369b7", // 2025-03-07T16:05:31.305Z
+          originBundleId: "0195715a-ce29-7c55-97d3-53af4fe369b7",
         },
       ];
 
@@ -1649,6 +1745,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true, // disabled
           id: "0195715d-42db-7475-9204-31819efc2f1d", // 2025-03-07T16:08:12.251Z
+          originBundleId: "0195715d-42db-7475-9204-31819efc2f1d",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1656,6 +1753,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "0195715a-ce29-7c55-97d3-53af4fe369b7", // 2025-03-07T16:05:31.305Z
+          originBundleId: "0195715a-ce29-7c55-97d3-53af4fe369b7",
         },
       ];
 
@@ -1677,6 +1775,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "01957165-bee7-7df3-a25d-6686f01b02ba", //2025-03-07T16:17:28.295Z
+          originBundleId: "01957165-bee7-7df3-a25d-6686f01b02ba",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1684,6 +1783,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "01957165-19fb-75af-a361-131c17a65ef2", // 2025-03-07T16:16:46.075Z
+          originBundleId: "01957165-19fb-75af-a361-131c17a65ef2",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1691,6 +1791,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "01957164-fbc6-785f-98ce-a6ae459f6e4f", // 2025-03-07T16:16:38.342Z
+          originBundleId: "01957164-fbc6-785f-98ce-a6ae459f6e4f",
         },
       ];
 
@@ -1712,6 +1813,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "0195716c-82f5-7e5e-ac8c-d4fbf5bc7555", // 2025-03-07T16:24:51.701Z
+          originBundleId: "0195716c-82f5-7e5e-ac8c-d4fbf5bc7555",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1719,6 +1821,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "01957167-0389-7064-8d86-f8af7950daed", // 2025-03-07T16:18:51.401Z
+          originBundleId: "01957167-0389-7064-8d86-f8af7950daed",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1726,6 +1829,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "01957165-bee7-7df3-a25d-6686f01b02ba", //2025-03-07T16:17:28.295Z
+          originBundleId: "01957165-bee7-7df3-a25d-6686f01b02ba",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1733,6 +1837,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "01957165-19fb-75af-a361-131c17a65ef2", // 2025-03-07T16:16:46.075Z
+          originBundleId: "01957165-19fb-75af-a361-131c17a65ef2",
         },
         {
           ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
@@ -1740,6 +1845,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "01957164-fbc6-785f-98ce-a6ae459f6e4f", // 2025-03-07T16:16:38.342Z
+          originBundleId: "01957164-fbc6-785f-98ce-a6ae459f6e4f",
         },
       ];
 
@@ -1766,6 +1872,7 @@ export const setupGetUpdateInfoTestSuite = ({
           shouldForceUpdate: false,
           enabled: true,
           id: "01957179-d99d-7fbb-bc1e-feff6b3236f0", // only available bundle, equal to minBundleId
+          originBundleId: "01957179-d99d-7fbb-bc1e-feff6b3236f0",
         },
       ];
 
@@ -1788,6 +1895,7 @@ export const setupGetUpdateInfoTestSuite = ({
           enabled: true,
           channel: "beta",
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -1811,6 +1919,7 @@ export const setupGetUpdateInfoTestSuite = ({
           enabled: true,
           channel: "beta",
           id: "00000000-0000-0000-0000-000000000001",
+          originBundleId: "00000000-0000-0000-0000-000000000001",
         },
       ];
 
@@ -1838,6 +1947,7 @@ export const setupGetUpdateInfoTestSuite = ({
           enabled: true,
           shouldForceUpdate: false,
           id: "01957b63-7d11-7281-b8e7-1120ccfdb8ab",
+          originBundleId: "01957b63-7d11-7281-b8e7-1120ccfdb8ab",
         },
       ];
 
@@ -1875,6 +1985,7 @@ export const setupGetUpdateInfoTestSuite = ({
           enabled: true,
           shouldForceUpdate: true,
           id: "01963024-c131-7971-8725-ab47e232df40",
+          originBundleId: "01963024-c131-7971-8725-ab47e232df40",
           platform: "ios",
           fingerprintHash: "hash1",
         },

--- a/plugins/aws/src/s3Database.spec.ts
+++ b/plugins/aws/src/s3Database.spec.ts
@@ -26,6 +26,7 @@ const DEFAULT_BUNDLE: Omit<
   shouldForceUpdate: false,
   storageUri: "s3://test-bucket/test-key",
   fingerprintHash: null,
+  originBundleId: "DEFAULT",
 };
 
 const createBundleJson = (
@@ -39,6 +40,7 @@ const createBundleJson = (
   id,
   platform,
   targetAppVersion,
+  originBundleId: id,
 });
 
 const createBundleJsonFingerprint = (
@@ -53,6 +55,7 @@ const createBundleJsonFingerprint = (
   platform,
   fingerprintHash,
   targetAppVersion: null,
+  originBundleId: id,
 });
 
 // fakeStore simulates files stored in S3
@@ -639,6 +642,7 @@ describe("s3Database plugin", () => {
       targetAppVersion: "2.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle1",
     } as const;
 
     const bundle2 = {
@@ -653,6 +657,7 @@ describe("s3Database plugin", () => {
       targetAppVersion: "1.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle2",
     } as const;
 
     const bundle3 = {
@@ -667,6 +672,7 @@ describe("s3Database plugin", () => {
       targetAppVersion: "1.5.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle3",
     } as const;
 
     await plugin.appendBundle(bundle1);
@@ -706,6 +712,7 @@ describe("s3Database plugin", () => {
       targetAppVersion: "2.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle1",
     } as const;
 
     const bundle2 = {
@@ -720,6 +727,7 @@ describe("s3Database plugin", () => {
       targetAppVersion: "1.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle2",
     } as const;
 
     const bundle3 = {
@@ -734,6 +742,7 @@ describe("s3Database plugin", () => {
       targetAppVersion: "1.5.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle3",
     } as const;
 
     await plugin.appendBundle(bundle1);

--- a/plugins/cloudflare/src/d1Database.ts
+++ b/plugins/cloudflare/src/d1Database.ts
@@ -69,6 +69,7 @@ function transformRowToBundle(row: SnakeCaseBundle): Bundle {
     storageUri: row.storage_uri,
     fingerprintHash: row.fingerprint_hash,
     metadata: row?.metadata ? JSON.parse(row?.metadata as string) : {},
+    originBundleId: row.origin_bundle_id || row.id,
   };
 }
 
@@ -221,9 +222,10 @@ export const d1Database = createDatabasePlugin<D1DatabaseConfig>({
                 target_app_version,
                 storage_uri,
                 fingerprint_hash,
-                metadata
+                metadata,
+                origin_bundle_id
               )
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             `);
 
             const params = [
@@ -241,6 +243,7 @@ export const d1Database = createDatabasePlugin<D1DatabaseConfig>({
               bundle.metadata
                 ? JSON.stringify(bundle.metadata)
                 : JSON.stringify({}),
+              bundle.originBundleId || bundle.id,
             ];
 
             await cf.d1.database.query(config.databaseId, {

--- a/plugins/cloudflare/worker/migrations/0004_hot-updater_add_origin_bundle_id.sql
+++ b/plugins/cloudflare/worker/migrations/0004_hot-updater_add_origin_bundle_id.sql
@@ -1,0 +1,74 @@
+-- Migration number: 0004
+-- Add origin_bundle_id column to track the original bundle resource identity.
+-- For directly deployed bundles, origin_bundle_id equals the bundle's own id.
+-- For copy-promoted bundles, origin_bundle_id is propagated from the source.
+
+ALTER TABLE bundles ADD COLUMN origin_bundle_id TEXT;
+
+-- Backfill: extract the UUID segment from storage_uri.
+-- storage_uri format: "protocol://bucket/[basePath/]<uuid>/filename"
+-- 1. Strip filename: RTRIM(uri, non-slash-chars) -> "protocol://bucket/.../uuid/"
+-- 2. Remove trailing slash -> "protocol://bucket/.../uuid"
+-- 3. Strip parent path: REPLACE(dir, RTRIM(dir, non-slash-chars), '') -> "uuid"
+UPDATE bundles
+SET origin_bundle_id = REPLACE(
+  SUBSTR(
+    RTRIM(storage_uri, REPLACE(storage_uri, '/', '')),
+    1,
+    LENGTH(RTRIM(storage_uri, REPLACE(storage_uri, '/', ''))) - 1
+  ),
+  RTRIM(
+    SUBSTR(
+      RTRIM(storage_uri, REPLACE(storage_uri, '/', '')),
+      1,
+      LENGTH(RTRIM(storage_uri, REPLACE(storage_uri, '/', ''))) - 1
+    ),
+    REPLACE(
+      SUBSTR(
+        RTRIM(storage_uri, REPLACE(storage_uri, '/', '')),
+        1,
+        LENGTH(RTRIM(storage_uri, REPLACE(storage_uri, '/', ''))) - 1
+      ),
+      '/',
+      ''
+    )
+  ),
+  ''
+)
+WHERE origin_bundle_id IS NULL AND storage_uri IS NOT NULL;
+
+-- Fallback for any rows where extraction failed or storage_uri is null
+UPDATE bundles
+SET origin_bundle_id = id
+WHERE origin_bundle_id IS NULL OR origin_bundle_id = '';
+
+-- Recreate table with NOT NULL constraint
+CREATE TABLE bundles_temp (
+    id TEXT PRIMARY KEY,
+    platform TEXT NOT NULL,
+    should_force_update INTEGER NOT NULL,
+    enabled INTEGER NOT NULL,
+    file_hash TEXT NOT NULL,
+    git_commit_hash TEXT,
+    message TEXT,
+    channel TEXT NOT NULL DEFAULT 'production',
+    storage_uri TEXT NOT NULL,
+    target_app_version TEXT,
+    fingerprint_hash TEXT,
+    metadata JSONB DEFAULT '{}',
+    origin_bundle_id TEXT NOT NULL,
+    CHECK ((target_app_version IS NOT NULL) OR (fingerprint_hash IS NOT NULL))
+);
+
+INSERT INTO bundles_temp
+SELECT id, platform, should_force_update, enabled, file_hash, git_commit_hash, message, channel, storage_uri, target_app_version, fingerprint_hash, metadata, origin_bundle_id
+FROM bundles;
+
+DROP TABLE bundles;
+
+ALTER TABLE bundles_temp RENAME TO bundles;
+
+CREATE INDEX bundles_target_app_version_idx ON bundles(target_app_version);
+CREATE INDEX bundles_fingerprint_hash_idx ON bundles(fingerprint_hash);
+CREATE INDEX bundles_channel_idx ON bundles(channel);
+CREATE INDEX bundles_origin_bundle_id_idx ON bundles(origin_bundle_id);

--- a/plugins/cloudflare/worker/src/getUpdateInfo.ts
+++ b/plugins/cloudflare/worker/src/getUpdateInfo.ts
@@ -56,13 +56,13 @@ const appVersionStrategy = async (
     FROM bundles b, input
     WHERE b.enabled = 1
       AND b.platform = input.app_platform
-      AND b.id >= input.bundle_id
-      AND b.id >= input.min_bundle_id
+      AND b.origin_bundle_id > input.bundle_id
+      AND b.origin_bundle_id >= input.min_bundle_id
       AND b.channel = input.channel
       AND b.target_app_version IN (${targetAppVersionList
         .map((version) => `'${version}'`)
         .join(",")})
-    ORDER BY b.id DESC
+    ORDER BY b.origin_bundle_id DESC
     LIMIT 1
   ),
   rollback_candidate AS (
@@ -76,9 +76,9 @@ const appVersionStrategy = async (
     FROM bundles b, input
     WHERE b.enabled = 1
       AND b.platform = input.app_platform
-      AND b.id < input.bundle_id
-      AND b.id >= input.min_bundle_id
-    ORDER BY b.id DESC
+      AND b.origin_bundle_id < input.bundle_id
+      AND b.origin_bundle_id >= input.min_bundle_id
+    ORDER BY b.origin_bundle_id DESC
     LIMIT 1
   ),
   final_result AS (
@@ -88,8 +88,7 @@ const appVersionStrategy = async (
     WHERE NOT EXISTS (SELECT 1 FROM update_candidate)
   )
   SELECT id, should_force_update, message, status, storage_uri, file_hash
-  FROM final_result, input
-  WHERE id <> bundle_id
+  FROM final_result
 
   UNION ALL
 
@@ -161,11 +160,11 @@ export const fingerprintStrategy = async (
     FROM bundles b, input
     WHERE b.enabled = 1
       AND b.platform = input.app_platform
-      AND b.id >= input.bundle_id
-      AND b.id >= input.min_bundle_id
+      AND b.origin_bundle_id > input.bundle_id
+      AND b.origin_bundle_id >= input.min_bundle_id
       AND b.channel = input.channel
       AND b.fingerprint_hash = input.fingerprint_hash
-    ORDER BY b.id DESC
+    ORDER BY b.origin_bundle_id DESC
     LIMIT 1
   ),
   rollback_candidate AS (
@@ -179,11 +178,11 @@ export const fingerprintStrategy = async (
     FROM bundles b, input
     WHERE b.enabled = 1
       AND b.platform = input.app_platform
-      AND b.id < input.bundle_id
-      AND b.id >= input.min_bundle_id
+      AND b.origin_bundle_id < input.bundle_id
+      AND b.origin_bundle_id >= input.min_bundle_id
       AND b.channel = input.channel
       AND b.fingerprint_hash = input.fingerprint_hash
-    ORDER BY b.id DESC
+    ORDER BY b.origin_bundle_id DESC
     LIMIT 1
   ),
   final_result AS (
@@ -193,8 +192,7 @@ export const fingerprintStrategy = async (
     WHERE NOT EXISTS (SELECT 1 FROM update_candidate)
   )
   SELECT id, should_force_update, message, status, storage_uri, file_hash
-  FROM final_result, input
-  WHERE id <> bundle_id
+  FROM final_result
 
   UNION ALL
 

--- a/plugins/firebase/firebase/functions/getUpdateInfo.ts
+++ b/plugins/firebase/firebase/functions/getUpdateInfo.ts
@@ -32,6 +32,7 @@ const convertToBundle = (data: any): Bundle => ({
   gitCommitHash: data.git_commit_hash,
   fingerprintHash: data.fingerprint_hash,
   storageUri: data.storage_uri,
+  originBundleId: data.origin_bundle_id || data.id,
 });
 
 const makeResponse = (bundle: Bundle, status: UpdateStatus): UpdateInfo => ({
@@ -68,15 +69,21 @@ const fingerprintStrategy = async (
   }: FingerprintGetBundlesArgs,
 ): Promise<UpdateInfo | null> => {
   try {
-    let currentBundle: Bundle | null = null;
+    // Check if client's current bundle exists in the requested channel
     if (bundleId !== NIL_UUID) {
-      const doc = await db.collection("bundles").doc(bundleId).get();
-      if (doc.exists) {
-        const data = doc.data()!;
-        if (data.channel !== channel) {
-          return null;
+      const currentSnap = await db
+        .collection("bundles")
+        .where("origin_bundle_id", "==", bundleId)
+        .where("channel", "==", channel)
+        .limit(1)
+        .get();
+      if (currentSnap.empty) {
+        // Current bundle not found in this channel — may have been moved or deleted
+      } else {
+        const data = currentSnap.docs[0].data();
+        if (!data.enabled) {
+          // Current bundle is disabled — will fall through to rollback logic
         }
-        currentBundle = convertToBundle(data);
       }
     }
 
@@ -84,68 +91,80 @@ const fingerprintStrategy = async (
       return null;
     }
 
+    // Use origin_bundle_id for all ordering to treat copy-promoted bundles
+    // as bundles from their original build time
     const baseQuery = db
       .collection("bundles")
       .where("platform", "==", platform)
       .where("channel", "==", channel)
       .where("enabled", "==", true)
-      .where("id", ">=", minBundleId)
+      .where("origin_bundle_id", ">=", minBundleId)
       .where("fingerprint_hash", "==", fingerprintHash);
 
     let updateCandidate: Bundle | null = null;
     let rollbackCandidate: Bundle | null = null;
+    let currentBundle: Bundle | null = null;
 
     if (bundleId === NIL_UUID) {
-      const snap = await baseQuery.orderBy("id", "desc").limit(1).get();
+      const snap = await baseQuery
+        .orderBy("origin_bundle_id", "desc")
+        .limit(1)
+        .get();
       if (!snap.empty) {
-        const data = snap.docs[0].data();
-        updateCandidate = convertToBundle(data);
+        updateCandidate = convertToBundle(snap.docs[0].data());
       }
     } else {
+      // Find update candidate: origin_bundle_id > bundleId (strictly newer)
       const updateSnap = await baseQuery
-        .where("id", ">=", bundleId)
-        .orderBy("id", "desc")
+        .where("origin_bundle_id", ">", bundleId)
+        .orderBy("origin_bundle_id", "desc")
         .limit(1)
         .get();
       if (!updateSnap.empty) {
-        const data = updateSnap.docs[0].data();
-        updateCandidate = convertToBundle(data);
+        updateCandidate = convertToBundle(updateSnap.docs[0].data());
       }
 
+      // Check if current bundle exists in candidates
+      const currentSnap = await baseQuery
+        .where("origin_bundle_id", "==", bundleId)
+        .limit(1)
+        .get();
+      if (!currentSnap.empty) {
+        currentBundle = convertToBundle(currentSnap.docs[0].data());
+      }
+
+      // Find rollback candidate: origin_bundle_id < bundleId
       const rollbackSnap = await baseQuery
-        .where("id", "<", bundleId)
-        .orderBy("id", "desc")
+        .where("origin_bundle_id", "<", bundleId)
+        .orderBy("origin_bundle_id", "desc")
         .limit(1)
         .get();
       if (!rollbackSnap.empty) {
-        const data = rollbackSnap.docs[0].data();
-        rollbackCandidate = convertToBundle(data);
+        rollbackCandidate = convertToBundle(rollbackSnap.docs[0].data());
       }
     }
 
     if (bundleId === NIL_UUID) {
       return updateCandidate ? makeResponse(updateCandidate, "UPDATE") : null;
     }
-    if (updateCandidate && updateCandidate.id !== bundleId) {
+
+    if (currentBundle) {
+      // Current bundle exists and is enabled — check if there's a newer one
+      if (updateCandidate) {
+        return makeResponse(updateCandidate, "UPDATE");
+      }
+      return null;
+    }
+
+    // Current bundle not found in candidates
+    if (updateCandidate) {
       return makeResponse(updateCandidate, "UPDATE");
     }
-
-    if (updateCandidate && updateCandidate.id === bundleId) {
-      if (currentBundle?.enabled) {
-        return null;
-      }
-      return rollbackCandidate
-        ? makeResponse(rollbackCandidate, "ROLLBACK")
-        : INIT_BUNDLE_ROLLBACK_UPDATE_INFO;
+    if (rollbackCandidate) {
+      return makeResponse(rollbackCandidate, "ROLLBACK");
     }
 
-    if (!updateCandidate) {
-      if (rollbackCandidate) {
-        return makeResponse(rollbackCandidate, "ROLLBACK");
-      }
-      return bundleId === minBundleId ? null : INIT_BUNDLE_ROLLBACK_UPDATE_INFO;
-    }
-    return null;
+    return bundleId === minBundleId ? null : INIT_BUNDLE_ROLLBACK_UPDATE_INFO;
   } catch (error) {
     console.error("Error in getUpdateInfo:", error);
     throw error;
@@ -163,15 +182,16 @@ const appVersionStrategy = async (
   }: AppVersionGetBundlesArgs,
 ): Promise<UpdateInfo | null> => {
   try {
-    let currentBundle: Bundle | null = null;
+    // Check if client's current bundle exists in the requested channel
     if (bundleId !== NIL_UUID) {
-      const doc = await db.collection("bundles").doc(bundleId).get();
-      if (doc.exists) {
-        const data = doc.data()!;
-        if (data.channel !== channel) {
-          return null;
-        }
-        currentBundle = convertToBundle(data);
+      const currentSnap = await db
+        .collection("bundles")
+        .where("origin_bundle_id", "==", bundleId)
+        .where("channel", "==", channel)
+        .limit(1)
+        .get();
+      if (currentSnap.empty) {
+        // Current bundle not found in this channel
       }
     }
 
@@ -203,68 +223,80 @@ const appVersionStrategy = async (
       return bundleId === minBundleId ? null : INIT_BUNDLE_ROLLBACK_UPDATE_INFO;
     }
 
+    // Use origin_bundle_id for all ordering to treat copy-promoted bundles
+    // as bundles from their original build time
     const baseQuery = db
       .collection("bundles")
       .where("platform", "==", platform)
       .where("channel", "==", channel)
       .where("enabled", "==", true)
-      .where("id", ">=", minBundleId)
+      .where("origin_bundle_id", ">=", minBundleId)
       .where("target_app_version", "in", targetAppVersionList);
 
     let updateCandidate: Bundle | null = null;
     let rollbackCandidate: Bundle | null = null;
+    let currentBundle: Bundle | null = null;
 
     if (bundleId === NIL_UUID) {
-      const snap = await baseQuery.orderBy("id", "desc").limit(1).get();
+      const snap = await baseQuery
+        .orderBy("origin_bundle_id", "desc")
+        .limit(1)
+        .get();
       if (!snap.empty) {
-        const data = snap.docs[0].data();
-        updateCandidate = convertToBundle(data);
+        updateCandidate = convertToBundle(snap.docs[0].data());
       }
     } else {
+      // Find update candidate: origin_bundle_id > bundleId (strictly newer)
       const updateSnap = await baseQuery
-        .where("id", ">=", bundleId)
-        .orderBy("id", "desc")
+        .where("origin_bundle_id", ">", bundleId)
+        .orderBy("origin_bundle_id", "desc")
         .limit(1)
         .get();
       if (!updateSnap.empty) {
-        const data = updateSnap.docs[0].data();
-        updateCandidate = convertToBundle(data);
+        updateCandidate = convertToBundle(updateSnap.docs[0].data());
       }
 
+      // Check if current bundle exists in candidates
+      const currentSnap = await baseQuery
+        .where("origin_bundle_id", "==", bundleId)
+        .limit(1)
+        .get();
+      if (!currentSnap.empty) {
+        currentBundle = convertToBundle(currentSnap.docs[0].data());
+      }
+
+      // Find rollback candidate: origin_bundle_id < bundleId
       const rollbackSnap = await baseQuery
-        .where("id", "<", bundleId)
-        .orderBy("id", "desc")
+        .where("origin_bundle_id", "<", bundleId)
+        .orderBy("origin_bundle_id", "desc")
         .limit(1)
         .get();
       if (!rollbackSnap.empty) {
-        const data = rollbackSnap.docs[0].data();
-        rollbackCandidate = convertToBundle(data);
+        rollbackCandidate = convertToBundle(rollbackSnap.docs[0].data());
       }
     }
 
     if (bundleId === NIL_UUID) {
       return updateCandidate ? makeResponse(updateCandidate, "UPDATE") : null;
     }
-    if (updateCandidate && updateCandidate.id !== bundleId) {
+
+    if (currentBundle) {
+      // Current bundle exists and is enabled — check if there's a newer one
+      if (updateCandidate) {
+        return makeResponse(updateCandidate, "UPDATE");
+      }
+      return null;
+    }
+
+    // Current bundle not found in candidates
+    if (updateCandidate) {
       return makeResponse(updateCandidate, "UPDATE");
     }
-
-    if (updateCandidate && updateCandidate.id === bundleId) {
-      if (currentBundle?.enabled) {
-        return null;
-      }
-      return rollbackCandidate
-        ? makeResponse(rollbackCandidate, "ROLLBACK")
-        : INIT_BUNDLE_ROLLBACK_UPDATE_INFO;
+    if (rollbackCandidate) {
+      return makeResponse(rollbackCandidate, "ROLLBACK");
     }
 
-    if (!updateCandidate) {
-      if (rollbackCandidate) {
-        return makeResponse(rollbackCandidate, "ROLLBACK");
-      }
-      return bundleId === minBundleId ? null : INIT_BUNDLE_ROLLBACK_UPDATE_INFO;
-    }
-    return null;
+    return bundleId === minBundleId ? null : INIT_BUNDLE_ROLLBACK_UPDATE_INFO;
   } catch (error) {
     console.error("Error in getUpdateInfo:", error);
     throw error;

--- a/plugins/firebase/src/firebaseDatabase.spec.ts
+++ b/plugins/firebase/src/firebaseDatabase.spec.ts
@@ -40,6 +40,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "1.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle123",
     } as const;
     await plugin.appendBundle(snakeBundle);
     await plugin.commitBundle();
@@ -57,6 +58,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "1.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle123",
       metadata: {},
     });
   });
@@ -74,6 +76,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "2.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle1",
     } as const;
 
     const bundle2 = {
@@ -88,6 +91,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "1.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle2",
     } as const;
 
     const bundle3 = {
@@ -102,6 +106,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "1.5.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle3",
     } as const;
 
     await plugin.appendBundle(bundle1);
@@ -132,6 +137,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "2.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle1",
     } as const;
     const bundle2 = {
       id: "bundle2",
@@ -145,6 +151,7 @@ describe("firebaseDatabase plugin", () => {
       shouldForceUpdate: false,
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle2",
     } as const;
     await plugin.appendBundle(bundle1);
     await plugin.appendBundle(bundle2);
@@ -167,6 +174,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "1.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle1",
     });
 
     await plugin.commitBundle();
@@ -196,6 +204,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "1.0.x",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle1",
     });
 
     await plugin.commitBundle();
@@ -233,6 +242,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "1.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundleA",
     } as const;
     const bundleB = {
       id: "bundleB",
@@ -246,6 +256,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "1.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundleB",
     } as const;
     const bundleC = {
       id: "bundleC",
@@ -259,6 +270,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "1.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundleC",
     } as const;
 
     await plugin.appendBundle(bundleA);
@@ -285,6 +297,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "2.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle1",
     } as const;
 
     const bundle2 = {
@@ -299,6 +312,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "1.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle2",
     } as const;
 
     const bundle3 = {
@@ -313,6 +327,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "1.5.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle3",
     } as const;
 
     await plugin.appendBundle(bundle1);
@@ -352,6 +367,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "2.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle1",
     } as const;
 
     const bundle2 = {
@@ -366,6 +382,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "1.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle2",
     } as const;
 
     const bundle3 = {
@@ -380,6 +397,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "1.5.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle3",
     } as const;
 
     await plugin.appendBundle(bundle1);
@@ -432,6 +450,7 @@ describe("firebaseDatabase plugin", () => {
         targetAppVersion: "1.1.1",
         storageUri: "gs://test-bucket/test-key",
         fingerprintHash: null,
+        originBundleId: "bundleX",
       },
       {
         id: "bundleY",
@@ -445,6 +464,7 @@ describe("firebaseDatabase plugin", () => {
         targetAppVersion: "1.1.1",
         storageUri: "gs://test-bucket/test-key",
         fingerprintHash: null,
+        originBundleId: "bundleY",
       },
       {
         id: "bundleZ",
@@ -458,6 +478,7 @@ describe("firebaseDatabase plugin", () => {
         targetAppVersion: "1.1.1",
         storageUri: "gs://test-bucket/test-key",
         fingerprintHash: null,
+        originBundleId: "bundleZ",
       },
     ] as const;
 
@@ -494,6 +515,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: null,
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundleNoVersion",
     });
     await plugin.commitBundle();
 
@@ -516,6 +538,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "2.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundleDirect",
     } as const;
     await plugin.appendBundle(bundleDirect);
     await plugin.commitBundle();
@@ -544,6 +567,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "4.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundleTV1",
     });
     await plugin.commitBundle();
 
@@ -571,6 +595,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "5.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundleTV2",
     });
     await plugin.appendBundle({
       id: "bundleTV3",
@@ -584,6 +609,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "5.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundleTV3",
     });
     await plugin.commitBundle();
 
@@ -606,6 +632,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "5.1.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundleTV2",
     });
     await plugin.commitBundle();
 
@@ -635,6 +662,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "5.2.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundleTV3",
     });
     await plugin.commitBundle();
 
@@ -671,6 +699,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "2.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundleTV4",
     });
     await plugin.commitBundle();
     const tvDoc = await firestore
@@ -692,6 +721,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "2.0.1",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundleTV4",
     });
     await plugin.commitBundle();
 
@@ -716,6 +746,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "1.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle1",
     });
     await plugin.commitBundle();
 
@@ -737,6 +768,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "1.0.0",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundle1",
     });
     await plugin.commitBundle();
 
@@ -762,6 +794,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "1.1.1",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundleX",
       metadata: {},
     },
     {
@@ -776,6 +809,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "1.1.1",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundleY",
       metadata: {},
     },
     {
@@ -790,6 +824,7 @@ describe("firebaseDatabase plugin", () => {
       targetAppVersion: "1.1.1",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "bundleZ",
       metadata: {},
     },
   ];

--- a/plugins/firebase/src/firebaseDatabase.ts
+++ b/plugins/firebase/src/firebaseDatabase.ts
@@ -21,6 +21,7 @@ const convertToBundle = (firestoreData: SnakeCaseBundle): Bundle => ({
   storageUri: firestoreData.storage_uri,
   fingerprintHash: firestoreData.fingerprint_hash,
   metadata: firestoreData?.metadata ?? {},
+  originBundleId: firestoreData.origin_bundle_id || firestoreData.id,
 });
 
 export const firebaseDatabase = createDatabasePlugin<admin.AppOptions>({
@@ -157,6 +158,7 @@ export const firebaseDatabase = createDatabasePlugin<admin.AppOptions>({
                 storage_uri: data.storageUri,
                 fingerprint_hash: data.fingerprintHash,
                 metadata: data.metadata ?? {},
+                origin_bundle_id: data.originBundleId || data.id,
               } as SnakeCaseBundle;
 
               // Add channel to channels collection
@@ -212,6 +214,7 @@ export const firebaseDatabase = createDatabasePlugin<admin.AppOptions>({
                   storage_uri: data.storageUri,
                   fingerprint_hash: data.fingerprintHash,
                   metadata: data.metadata ?? {},
+                  origin_bundle_id: data.originBundleId || data.id,
                 } as SnakeCaseBundle,
                 { merge: true },
               );

--- a/plugins/js/src/checkForRollback.spec.ts
+++ b/plugins/js/src/checkForRollback.spec.ts
@@ -19,21 +19,24 @@ describe("checkForRollback", () => {
   it("should return availableOldVersion if enabled is null or undefined", () => {
     const bundles: Bundle[] = [
       {
-        id: "00000000-0000-0000-0000-000000000001",
-        enabled: true,
         ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
+        id: "00000000-0000-0000-0000-000000000001",
+        originBundleId: "00000000-0000-0000-0000-000000000001",
+        enabled: true,
       },
       {
-        id: "00000000-0000-0000-0000-000000000002",
-        enabled: false,
         ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
+        id: "00000000-0000-0000-0000-000000000002",
+        originBundleId: "00000000-0000-0000-0000-000000000002",
+        enabled: false,
         storageUri:
           "storage://my-app/00000000-0000-0000-0000-000000000000/bundle.zip",
       },
       {
-        id: "00000000-0000-0000-0000-000000000003",
-        enabled: true,
         ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
+        id: "00000000-0000-0000-0000-000000000003",
+        originBundleId: "00000000-0000-0000-0000-000000000003",
+        enabled: true,
       },
     ];
     const currentBundleId = "00000000-0000-0000-0000-000000000004";
@@ -44,14 +47,16 @@ describe("checkForRollback", () => {
   it("should return undefined if no matching bundle is found", () => {
     const bundles: Bundle[] = [
       {
-        id: "00000000-0000-0000-0000-000000000001",
-        enabled: true,
         ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
+        id: "00000000-0000-0000-0000-000000000001",
+        originBundleId: "00000000-0000-0000-0000-000000000001",
+        enabled: true,
       },
       {
-        id: "00000000-0000-0000-0000-000000000002",
-        enabled: false,
         ...DEFAULT_BUNDLE_FINGERPRINT_STRATEGY,
+        id: "00000000-0000-0000-0000-000000000002",
+        originBundleId: "00000000-0000-0000-0000-000000000002",
+        enabled: false,
       },
     ];
     const currentBundleId = "00000000-0000-0000-0000-000000000003";

--- a/plugins/js/src/checkForRollback.ts
+++ b/plugins/js/src/checkForRollback.ts
@@ -13,9 +13,12 @@ export const checkForRollback = (
     return true;
   }
 
-  const enabled = bundles.find((item) => item.id === currentBundleId)?.enabled;
+  const enabled = bundles.find(
+    (item) => item.originBundleId === currentBundleId,
+  )?.enabled;
   const availableOldVersion = bundles.find(
-    (item) => item.id.localeCompare(currentBundleId) < 0 && item.enabled,
+    (item) =>
+      item.originBundleId.localeCompare(currentBundleId) < 0 && item.enabled,
   )?.enabled;
 
   if (isNullable(enabled)) {

--- a/plugins/js/src/getUpdateInfo.ts
+++ b/plugins/js/src/getUpdateInfo.ts
@@ -52,6 +52,8 @@ const appVersionStrategy = async (
   }: AppVersionGetBundlesArgs,
 ): Promise<UpdateInfo | null> => {
   // Initial filtering: apply platform, channel, semver conditions, enabled status, and minBundleId condition
+  // Use originBundleId for version ordering so copy-promoted bundles are treated
+  // as bundles from their original build time, not their promotion time.
   const candidateBundles: Bundle[] = [];
 
   for (const b of bundles) {
@@ -61,7 +63,7 @@ const appVersionStrategy = async (
       !b.targetAppVersion ||
       !semverSatisfies(b.targetAppVersion, appVersion) ||
       !b.enabled ||
-      (minBundleId && b.id.localeCompare(minBundleId) < 0)
+      (minBundleId && b.originBundleId.localeCompare(minBundleId) < 0)
     ) {
       continue;
     }
@@ -85,25 +87,31 @@ const appVersionStrategy = async (
   let currentBundle: Bundle | undefined;
 
   for (const b of candidateBundles) {
-    // Latest bundle (bundle with the largest ID)
-    if (!latestCandidate || b.id.localeCompare(latestCandidate.id) > 0) {
+    // Latest bundle (bundle with the largest originBundleId)
+    if (
+      !latestCandidate ||
+      b.originBundleId.localeCompare(latestCandidate.originBundleId) > 0
+    ) {
       latestCandidate = b;
     }
-    // Check if current bundle exists
-    if (b.id === bundleId) {
+    // Check if current bundle exists (originBundleId matches client's bundleId)
+    if (b.originBundleId === bundleId) {
       currentBundle = b;
     } else if (bundleId !== NIL_UUID) {
-      // Update candidate: largest ID among those greater than the current bundle
-      if (b.id.localeCompare(bundleId) > 0) {
-        if (!updateCandidate || b.id.localeCompare(updateCandidate.id) > 0) {
+      // Update candidate: largest originBundleId among those greater than the current bundle
+      if (b.originBundleId.localeCompare(bundleId) > 0) {
+        if (
+          !updateCandidate ||
+          b.originBundleId.localeCompare(updateCandidate.originBundleId) > 0
+        ) {
           updateCandidate = b;
         }
       }
-      // Rollback candidate: largest ID among those smaller than the current bundle
-      else if (b.id.localeCompare(bundleId) < 0) {
+      // Rollback candidate: largest originBundleId among those smaller than the current bundle
+      else if (b.originBundleId.localeCompare(bundleId) < 0) {
         if (
           !rollbackCandidate ||
-          b.id.localeCompare(rollbackCandidate.id) > 0
+          b.originBundleId.localeCompare(rollbackCandidate.originBundleId) > 0
         ) {
           rollbackCandidate = b;
         }
@@ -113,7 +121,10 @@ const appVersionStrategy = async (
 
   if (bundleId === NIL_UUID) {
     // For NIL_UUID, return an update if there's a latest candidate
-    if (latestCandidate && latestCandidate.id.localeCompare(bundleId) > 0) {
+    if (
+      latestCandidate &&
+      latestCandidate.originBundleId.localeCompare(bundleId) > 0
+    ) {
       return makeResponse(latestCandidate, "UPDATE");
     }
     return null;
@@ -123,7 +134,9 @@ const appVersionStrategy = async (
     // If current bundle exists, compare with latest candidate to determine update
     if (
       latestCandidate &&
-      latestCandidate.id.localeCompare(currentBundle.id) > 0
+      latestCandidate.originBundleId.localeCompare(
+        currentBundle.originBundleId,
+      ) > 0
     ) {
       return makeResponse(latestCandidate, "UPDATE");
     }
@@ -163,7 +176,7 @@ const fingerprintStrategy = async (
       !b.fingerprintHash ||
       b.fingerprintHash !== fingerprintHash ||
       !b.enabled ||
-      (minBundleId && b.id.localeCompare(minBundleId) < 0)
+      (minBundleId && b.originBundleId.localeCompare(minBundleId) < 0)
     ) {
       continue;
     }
@@ -187,25 +200,31 @@ const fingerprintStrategy = async (
   let currentBundle: Bundle | undefined;
 
   for (const b of candidateBundles) {
-    // Latest bundle (bundle with the largest ID)
-    if (!latestCandidate || b.id.localeCompare(latestCandidate.id) > 0) {
+    // Latest bundle (bundle with the largest originBundleId)
+    if (
+      !latestCandidate ||
+      b.originBundleId.localeCompare(latestCandidate.originBundleId) > 0
+    ) {
       latestCandidate = b;
     }
-    // Check if current bundle exists
-    if (b.id === bundleId) {
+    // Check if current bundle exists (originBundleId matches client's bundleId)
+    if (b.originBundleId === bundleId) {
       currentBundle = b;
     } else if (bundleId !== NIL_UUID) {
-      // Update candidate: largest ID among those greater than the current bundle
-      if (b.id.localeCompare(bundleId) > 0) {
-        if (!updateCandidate || b.id.localeCompare(updateCandidate.id) > 0) {
+      // Update candidate: largest originBundleId among those greater than the current bundle
+      if (b.originBundleId.localeCompare(bundleId) > 0) {
+        if (
+          !updateCandidate ||
+          b.originBundleId.localeCompare(updateCandidate.originBundleId) > 0
+        ) {
           updateCandidate = b;
         }
       }
-      // Rollback candidate: largest ID among those smaller than the current bundle
-      else if (b.id.localeCompare(bundleId) < 0) {
+      // Rollback candidate: largest originBundleId among those smaller than the current bundle
+      else if (b.originBundleId.localeCompare(bundleId) < 0) {
         if (
           !rollbackCandidate ||
-          b.id.localeCompare(rollbackCandidate.id) > 0
+          b.originBundleId.localeCompare(rollbackCandidate.originBundleId) > 0
         ) {
           rollbackCandidate = b;
         }
@@ -215,7 +234,10 @@ const fingerprintStrategy = async (
 
   if (bundleId === NIL_UUID) {
     // For NIL_UUID, return an update if there's a latest candidate
-    if (latestCandidate && latestCandidate.id.localeCompare(bundleId) > 0) {
+    if (
+      latestCandidate &&
+      latestCandidate.originBundleId.localeCompare(bundleId) > 0
+    ) {
       return makeResponse(latestCandidate, "UPDATE");
     }
     return null;
@@ -225,7 +247,9 @@ const fingerprintStrategy = async (
     // If current bundle exists, compare with latest candidate to determine update
     if (
       latestCandidate &&
-      latestCandidate.id.localeCompare(currentBundle.id) > 0
+      latestCandidate.originBundleId.localeCompare(
+        currentBundle.originBundleId,
+      ) > 0
     ) {
       return makeResponse(latestCandidate, "UPDATE");
     }

--- a/plugins/mock/src/test/mockDatabase.spec.ts
+++ b/plugins/mock/src/test/mockDatabase.spec.ts
@@ -5,6 +5,7 @@ import { mockDatabase } from "../mockDatabase";
 const DEFAULT_BUNDLES: Bundle[] = [
   {
     id: "0194ed78-ee7f-7d55-88f2-0511cbacc8f1",
+    originBundleId: "0194ed78-ee7f-7d55-88f2-0511cbacc8f1",
     enabled: true,
     channel: "production",
     shouldForceUpdate: false,
@@ -20,6 +21,7 @@ const DEFAULT_BUNDLES: Bundle[] = [
   },
   {
     id: "0194ed78-d791-753c-ba37-abb7259edcc8",
+    originBundleId: "0194ed78-d791-753c-ba37-abb7259edcc8",
     enabled: true,
     channel: "production",
     shouldForceUpdate: false,
@@ -69,6 +71,7 @@ describe("mockDatabase", () => {
   it("should return correct pagination info for single page", async () => {
     const bundle1 = {
       id: "bundle1",
+      originBundleId: "bundle1",
       channel: "production",
       enabled: true,
       shouldForceUpdate: true,
@@ -84,6 +87,7 @@ describe("mockDatabase", () => {
 
     const bundle2 = {
       id: "bundle2",
+      originBundleId: "bundle2",
       channel: "production",
       enabled: false,
       shouldForceUpdate: false,
@@ -99,6 +103,7 @@ describe("mockDatabase", () => {
 
     const bundle3 = {
       id: "bundle3",
+      originBundleId: "bundle3",
       channel: "staging",
       enabled: true,
       shouldForceUpdate: false,
@@ -139,6 +144,7 @@ describe("mockDatabase", () => {
   it("should return correct pagination info for multiple pages", async () => {
     const bundle1 = {
       id: "bundle1",
+      originBundleId: "bundle1",
       channel: "production",
       enabled: true,
       shouldForceUpdate: true,
@@ -154,6 +160,7 @@ describe("mockDatabase", () => {
 
     const bundle2 = {
       id: "bundle2",
+      originBundleId: "bundle2",
       channel: "production",
       enabled: false,
       shouldForceUpdate: false,
@@ -169,6 +176,7 @@ describe("mockDatabase", () => {
 
     const bundle3 = {
       id: "bundle3",
+      originBundleId: "bundle3",
       channel: "production",
       enabled: true,
       shouldForceUpdate: false,
@@ -315,6 +323,7 @@ describe("mockDatabase", () => {
     const nonExistentBundle = {
       ...DEFAULT_BUNDLES_MOCK[0],
       id: "non-existent-bundle",
+      originBundleId: "non-existent-bundle",
     };
 
     await plugin.deleteBundle(nonExistentBundle);
@@ -380,11 +389,13 @@ describe("mockDatabase", () => {
       {
         ...DEFAULT_BUNDLES_MOCK[0],
         id: "bundle-prod",
+        originBundleId: "bundle-prod",
         channel: "production",
       },
       {
         ...DEFAULT_BUNDLES_MOCK[1],
         id: "bundle-staging",
+        originBundleId: "bundle-staging",
         channel: "staging",
       },
     ];
@@ -413,16 +424,19 @@ describe("mockDatabase", () => {
       {
         ...DEFAULT_BUNDLES_MOCK[0],
         id: "bundle-1",
+        originBundleId: "bundle-1",
         channel: "production",
       },
       {
         ...DEFAULT_BUNDLES_MOCK[1],
         id: "bundle-2",
+        originBundleId: "bundle-2",
         channel: "production",
       },
       {
         ...DEFAULT_BUNDLES_MOCK[0],
         id: "bundle-3",
+        originBundleId: "bundle-3",
         channel: "production",
       },
     ];
@@ -467,6 +481,7 @@ describe("mockDatabase", () => {
   it("should work with appendBundle and deleteBundle workflow", async () => {
     const newBundle: Bundle = {
       id: "new-bundle",
+      originBundleId: "new-bundle",
       channel: "test",
       enabled: true,
       shouldForceUpdate: false,
@@ -504,6 +519,7 @@ describe("mockDatabase", () => {
   it("should process mixed operations in sequence", async () => {
     const bundle1 = {
       id: "bundle1",
+      originBundleId: "bundle1",
       channel: "production",
       enabled: true,
       shouldForceUpdate: false,
@@ -519,6 +535,7 @@ describe("mockDatabase", () => {
 
     const bundle2 = {
       id: "bundle2",
+      originBundleId: "bundle2",
       channel: "production",
       enabled: false,
       shouldForceUpdate: false,

--- a/plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts
+++ b/plugins/plugin-core/src/createBlobDatabasePlugin.spec.ts
@@ -13,6 +13,7 @@ const DEFAULT_BUNDLE: Omit<
   shouldForceUpdate: false,
   storageUri:
     "storage://my-app/00000000-0000-0000-0000-000000000000/bundle.zip",
+  originBundleId: "DEFAULT",
   fingerprintHash: null,
 };
 
@@ -25,6 +26,7 @@ const createBundleJson = (
   ...DEFAULT_BUNDLE,
   channel,
   id,
+  originBundleId: id,
   platform,
   targetAppVersion,
 });
@@ -32,6 +34,7 @@ const createBundleJson = (
 const bundlesData = [
   {
     id: "bundleX",
+    originBundleId: "bundleX",
     channel: "production",
     enabled: true,
     shouldForceUpdate: false,
@@ -45,6 +48,7 @@ const bundlesData = [
   },
   {
     id: "bundleY",
+    originBundleId: "bundleY",
     channel: "production",
     enabled: true,
     shouldForceUpdate: false,
@@ -58,6 +62,7 @@ const bundlesData = [
   },
   {
     id: "bundleZ",
+    originBundleId: "bundleZ",
     channel: "staging",
     enabled: true,
     shouldForceUpdate: false,
@@ -963,8 +968,16 @@ describe("blobDatabase plugin", () => {
 
   it("should keep update.json file when other bundles remain", async () => {
     // Setup - create bundles in same platform/channel
-    const bundle1 = { ...bundlesData[0], id: "bundleA" };
-    const bundle2 = { ...bundlesData[0], id: "bundleB" };
+    const bundle1 = {
+      ...bundlesData[0],
+      id: "bundleA",
+      originBundleId: "bundleA",
+    };
+    const bundle2 = {
+      ...bundlesData[0],
+      id: "bundleB",
+      originBundleId: "bundleB",
+    };
 
     await plugin.appendBundle(bundle1);
     await plugin.appendBundle(bundle2);
@@ -1012,9 +1025,21 @@ describe("blobDatabase plugin", () => {
 
   it("should sort remaining bundles after deletion", async () => {
     // Setup
-    const bundle1 = { ...bundlesData[0], id: "bundleA" };
-    const bundle2 = { ...bundlesData[0], id: "bundleB" };
-    const bundle3 = { ...bundlesData[0], id: "bundleC" };
+    const bundle1 = {
+      ...bundlesData[0],
+      id: "bundleA",
+      originBundleId: "bundleA",
+    };
+    const bundle2 = {
+      ...bundlesData[0],
+      id: "bundleB",
+      originBundleId: "bundleB",
+    };
+    const bundle3 = {
+      ...bundlesData[0],
+      id: "bundleC",
+      originBundleId: "bundleC",
+    };
 
     await plugin.appendBundle(bundle1);
     await plugin.appendBundle(bundle2);
@@ -1125,9 +1150,21 @@ describe("blobDatabase plugin", () => {
 
   it("should work with getBundles pagination", async () => {
     // Setup - create multiple bundles
-    const bundle1 = { ...bundlesData[0], id: "bundle1" };
-    const bundle2 = { ...bundlesData[0], id: "bundle2" };
-    const bundle3 = { ...bundlesData[0], id: "bundle3" };
+    const bundle1 = {
+      ...bundlesData[0],
+      id: "bundle1",
+      originBundleId: "bundle1",
+    };
+    const bundle2 = {
+      ...bundlesData[0],
+      id: "bundle2",
+      originBundleId: "bundle2",
+    };
+    const bundle3 = {
+      ...bundlesData[0],
+      id: "bundle3",
+      originBundleId: "bundle3",
+    };
 
     await plugin.appendBundle(bundle1);
     await plugin.appendBundle(bundle2);

--- a/plugins/postgres/sql/bundles.sql
+++ b/plugins/postgres/sql/bundles.sql
@@ -17,9 +17,11 @@ CREATE TABLE bundles (
     CONSTRAINT check_version_or_fingerprint CHECK (
         (target_app_version IS NOT NULL) OR (fingerprint_hash IS NOT NULL)
     ),
-    metadata jsonb DEFAULT '{}'::jsonb
+    metadata jsonb DEFAULT '{}'::jsonb,
+    origin_bundle_id uuid NOT NULL
 );
 
 CREATE INDEX bundles_target_app_version_idx ON bundles(target_app_version);
 CREATE INDEX bundles_fingerprint_hash_idx ON bundles(fingerprint_hash);
 CREATE INDEX bundles_channel_idx ON bundles(channel);
+CREATE INDEX bundles_origin_bundle_id_idx ON bundles(origin_bundle_id);

--- a/plugins/postgres/sql/get_update_info_by_app_version.sql
+++ b/plugins/postgres/sql/get_update_info_by_app_version.sql
@@ -34,11 +34,11 @@ BEGIN
         FROM bundles b
         WHERE b.enabled = TRUE
           AND b.platform = app_platform
-          AND b.id >= bundle_id
-          AND b.id > min_bundle_id
+          AND b.origin_bundle_id > bundle_id
+          AND b.origin_bundle_id > min_bundle_id
           AND b.target_app_version IN (SELECT unnest(target_app_version_list))
           AND b.channel = target_channel
-        ORDER BY b.id DESC
+        ORDER BY b.origin_bundle_id DESC
         LIMIT 1
     ),
     rollback_candidate AS (
@@ -52,9 +52,9 @@ BEGIN
         FROM bundles b
         WHERE b.enabled = TRUE
           AND b.platform = app_platform
-          AND b.id < bundle_id
-          AND b.id > min_bundle_id
-        ORDER BY b.id DESC
+          AND b.origin_bundle_id < bundle_id
+          AND b.origin_bundle_id > min_bundle_id
+        ORDER BY b.origin_bundle_id DESC
         LIMIT 1
     ),
     final_result AS (
@@ -65,7 +65,6 @@ BEGIN
     )
     SELECT *
     FROM final_result
-    WHERE final_result.id != bundle_id
 
     UNION ALL
 
@@ -82,7 +81,7 @@ BEGIN
       AND NOT EXISTS (
           SELECT 1
           FROM bundles b
-          WHERE b.id = bundle_id
+          WHERE b.origin_bundle_id = bundle_id
             AND b.enabled = TRUE
             AND b.platform = app_platform
       );

--- a/plugins/postgres/sql/get_update_info_by_fingerprint_hash.sql
+++ b/plugins/postgres/sql/get_update_info_by_fingerprint_hash.sql
@@ -33,11 +33,11 @@ BEGIN
         FROM bundles b
         WHERE b.enabled = TRUE
           AND b.platform = app_platform
-          AND b.id >= bundle_id
-          AND b.id > min_bundle_id
+          AND b.origin_bundle_id > bundle_id
+          AND b.origin_bundle_id > min_bundle_id
           AND b.channel = target_channel
           AND b.fingerprint_hash = target_fingerprint_hash
-        ORDER BY b.id DESC
+        ORDER BY b.origin_bundle_id DESC
         LIMIT 1
     ),
     rollback_candidate AS (
@@ -51,11 +51,11 @@ BEGIN
         FROM bundles b
         WHERE b.enabled = TRUE
           AND b.platform = app_platform
-          AND b.id < bundle_id
-          AND b.id > min_bundle_id
+          AND b.origin_bundle_id < bundle_id
+          AND b.origin_bundle_id > min_bundle_id
           AND b.channel = target_channel
           AND b.fingerprint_hash = target_fingerprint_hash
-        ORDER BY b.id DESC
+        ORDER BY b.origin_bundle_id DESC
         LIMIT 1
     ),
     final_result AS (
@@ -66,7 +66,6 @@ BEGIN
     )
     SELECT *
     FROM final_result
-    WHERE final_result.id != bundle_id
 
     UNION ALL
 
@@ -83,7 +82,7 @@ BEGIN
       AND NOT EXISTS (
           SELECT 1
           FROM bundles b
-          WHERE b.id = bundle_id
+          WHERE b.origin_bundle_id = bundle_id
             AND b.enabled = TRUE
             AND b.platform = app_platform
       );

--- a/plugins/postgres/src/postgres.ts
+++ b/plugins/postgres/src/postgres.ts
@@ -43,6 +43,7 @@ export const postgres = createDatabasePlugin<PostgresConfig>({
           channel: data.channel,
           storageUri: data.storage_uri,
           fingerprintHash: data.fingerprint_hash,
+          originBundleId: data.origin_bundle_id || data.id,
         } as Bundle;
       },
 
@@ -97,6 +98,7 @@ export const postgres = createDatabasePlugin<PostgresConfig>({
           channel: bundle.channel,
           storageUri: bundle.storage_uri,
           fingerprintHash: bundle.fingerprint_hash,
+          originBundleId: bundle.origin_bundle_id || bundle.id,
         })) as Bundle[];
 
         const pagination = calculatePagination(total, { limit, offset });
@@ -152,6 +154,7 @@ export const postgres = createDatabasePlugin<PostgresConfig>({
                   channel: bundle.channel,
                   storage_uri: bundle.storageUri,
                   fingerprint_hash: bundle.fingerprintHash,
+                  origin_bundle_id: bundle.originBundleId || bundle.id,
                 })
                 .onConflict((oc) =>
                   oc.column("id").doUpdateSet({
@@ -165,6 +168,7 @@ export const postgres = createDatabasePlugin<PostgresConfig>({
                     channel: bundle.channel,
                     storage_uri: bundle.storageUri,
                     fingerprint_hash: bundle.fingerprintHash,
+                    origin_bundle_id: bundle.originBundleId || bundle.id,
                   }),
                 )
                 .execute();

--- a/plugins/standalone/src/standaloneRepository.spec.ts
+++ b/plugins/standalone/src/standaloneRepository.spec.ts
@@ -36,6 +36,7 @@ const TEST_BUNDLE_1 = {
   targetAppVersion: "2.0.0",
   storageUri: "gs://test-bucket/test-key",
   fingerprintHash: null,
+  originBundleId: "bundle1",
 } as const;
 
 const TEST_BUNDLE_2 = {
@@ -50,6 +51,7 @@ const TEST_BUNDLE_2 = {
   targetAppVersion: "1.0.0",
   storageUri: "gs://test-bucket/test-key",
   fingerprintHash: null,
+  originBundleId: "bundle2",
 } as const;
 
 const TEST_BUNDLE_3 = {
@@ -64,6 +66,7 @@ const TEST_BUNDLE_3 = {
   targetAppVersion: "1.5.0",
   storageUri: "gs://test-bucket/test-key",
   fingerprintHash: null,
+  originBundleId: "bundle3",
 } as const;
 
 const testBundles: Bundle[] = [
@@ -76,6 +79,7 @@ const testBundles: Bundle[] = [
     channel: "production",
     storageUri: "gs://test-bucket/test-key",
     fingerprintHash: null,
+    originBundleId: "00000000-0000-0000-0000-000000000001",
   },
   TEST_BUNDLE_1,
   TEST_BUNDLE_2,
@@ -367,6 +371,7 @@ describe("Standalone Repository Plugin (Default Routes)", () => {
       channel: "production",
       storageUri: "gs://test-bucket/test-key",
       fingerprintHash: null,
+      originBundleId: "00000000-0000-0000-0000-000000000002",
     };
 
     await repo.appendBundle(newBundle);
@@ -607,6 +612,7 @@ describe("Standalone Repository Plugin (Default Routes)", () => {
           targetAppVersion: "*",
           storageUri: "gs://test-bucket/test-key",
           fingerprintHash: null,
+          originBundleId: `bundle-${index + 1}`,
         }),
       );
 

--- a/plugins/supabase/src/supabaseDatabase.ts
+++ b/plugins/supabase/src/supabaseDatabase.ts
@@ -24,7 +24,7 @@ export const supabaseDatabase = createDatabasePlugin<SupabaseDatabaseConfig>({
         const { data, error } = await supabase
           .from("bundles")
           .select(
-            "channel, enabled, should_force_update, file_hash, git_commit_hash, id, message, platform, target_app_version, fingerprint_hash, storage_uri, metadata",
+            "channel, enabled, should_force_update, file_hash, git_commit_hash, id, message, platform, target_app_version, fingerprint_hash, storage_uri, metadata, origin_bundle_id",
           )
           .eq("id", bundleId)
           .single();
@@ -45,6 +45,7 @@ export const supabaseDatabase = createDatabasePlugin<SupabaseDatabaseConfig>({
           fingerprintHash: data.fingerprint_hash,
           storageUri: data.storage_uri,
           metadata: data.metadata ?? {},
+          originBundleId: data.origin_bundle_id || data.id,
         } as Bundle;
       },
 
@@ -67,7 +68,7 @@ export const supabaseDatabase = createDatabasePlugin<SupabaseDatabaseConfig>({
         let query = supabase
           .from("bundles")
           .select(
-            "id, channel, enabled, platform, should_force_update, file_hash, git_commit_hash, message, fingerprint_hash, target_app_version, storage_uri, metadata",
+            "id, channel, enabled, platform, should_force_update, file_hash, git_commit_hash, message, fingerprint_hash, target_app_version, storage_uri, metadata, origin_bundle_id",
           )
           .order("id", { ascending: false });
 
@@ -103,6 +104,7 @@ export const supabaseDatabase = createDatabasePlugin<SupabaseDatabaseConfig>({
               fingerprintHash: bundle.fingerprint_hash,
               storageUri: bundle.storage_uri,
               metadata: bundle.metadata ?? {},
+              originBundleId: bundle.origin_bundle_id || bundle.id,
             }))
           : [];
 
@@ -156,6 +158,7 @@ export const supabaseDatabase = createDatabasePlugin<SupabaseDatabaseConfig>({
                 fingerprint_hash: bundle.fingerprintHash,
                 storage_uri: bundle.storageUri,
                 metadata: bundle.metadata,
+                origin_bundle_id: bundle.originBundleId || bundle.id,
               },
               { onConflict: "id" },
             );

--- a/plugins/supabase/supabase/migrations/20260311000000_hot-updater_add_origin_bundle_id.sql
+++ b/plugins/supabase/supabase/migrations/20260311000000_hot-updater_add_origin_bundle_id.sql
@@ -1,0 +1,207 @@
+-- Add origin_bundle_id column to track the original bundle resource identity.
+ALTER TABLE bundles ADD COLUMN origin_bundle_id uuid;
+
+-- Backfill: extract the UUID segment from storage_uri.
+-- storage_uri format: "protocol://bucket/[basePath/]<uuid>/filename"
+-- split_part with '/' gets segments; array_length - 1 is the UUID segment.
+UPDATE bundles
+SET origin_bundle_id = (
+  split_part(storage_uri, '/', array_length(string_to_array(storage_uri, '/'), 1) - 1)
+)::uuid
+WHERE origin_bundle_id IS NULL AND storage_uri IS NOT NULL;
+
+-- Fallback for any remaining rows
+UPDATE bundles
+SET origin_bundle_id = id
+WHERE origin_bundle_id IS NULL;
+
+-- Add NOT NULL constraint
+ALTER TABLE bundles ALTER COLUMN origin_bundle_id SET NOT NULL;
+
+-- Add index
+CREATE INDEX bundles_origin_bundle_id_idx ON bundles(origin_bundle_id);
+
+-- Update stored procedures to account for origin_bundle_id in update checks
+
+DROP FUNCTION IF EXISTS get_update_info_by_fingerprint_hash;
+DROP FUNCTION IF EXISTS get_update_info_by_app_version;
+
+-- HotUpdater.get_update_info_by_fingerprint_hash
+CREATE OR REPLACE FUNCTION get_update_info_by_fingerprint_hash (
+    app_platform   platforms,
+    bundle_id  uuid,
+    min_bundle_id uuid,
+    target_channel text,
+    target_fingerprint_hash text
+)
+RETURNS TABLE (
+    id            uuid,
+    should_force_update  boolean,
+    message       text,
+    status        text,
+    storage_uri   text,
+    file_hash     text
+)
+LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    NIL_UUID CONSTANT uuid := '00000000-0000-0000-0000-000000000000';
+BEGIN
+    RETURN QUERY
+    WITH update_candidate AS (
+        SELECT
+            b.id,
+            b.should_force_update,
+            b.message,
+            'UPDATE' AS status,
+            b.storage_uri,
+            b.file_hash
+        FROM bundles b
+        WHERE b.enabled = TRUE
+          AND b.platform = app_platform
+          AND b.origin_bundle_id > bundle_id
+          AND b.origin_bundle_id > min_bundle_id
+          AND b.channel = target_channel
+          AND b.fingerprint_hash = target_fingerprint_hash
+        ORDER BY b.origin_bundle_id DESC
+        LIMIT 1
+    ),
+    rollback_candidate AS (
+        SELECT
+            b.id,
+            TRUE AS should_force_update,
+            b.message,
+            'ROLLBACK' AS status,
+            b.storage_uri,
+            b.file_hash
+        FROM bundles b
+        WHERE b.enabled = TRUE
+          AND b.platform = app_platform
+          AND b.origin_bundle_id < bundle_id
+          AND b.origin_bundle_id > min_bundle_id
+          AND b.channel = target_channel
+          AND b.fingerprint_hash = target_fingerprint_hash
+        ORDER BY b.origin_bundle_id DESC
+        LIMIT 1
+    ),
+    final_result AS (
+        SELECT * FROM update_candidate
+        UNION ALL
+        SELECT * FROM rollback_candidate
+        WHERE NOT EXISTS (SELECT 1 FROM update_candidate)
+    )
+    SELECT *
+    FROM final_result
+
+    UNION ALL
+
+    SELECT
+        NIL_UUID      AS id,
+        TRUE          AS should_force_update,
+        NULL          AS message,
+        'ROLLBACK'    AS status,
+        NULL          AS storage_uri,
+        NULL          AS file_hash
+    WHERE (SELECT COUNT(*) FROM final_result) = 0
+      AND bundle_id != NIL_UUID
+      AND bundle_id > min_bundle_id
+      AND NOT EXISTS (
+          SELECT 1
+          FROM bundles b
+          WHERE b.origin_bundle_id = bundle_id
+            AND b.enabled = TRUE
+            AND b.platform = app_platform
+      );
+END;
+$$;
+
+
+-- HotUpdater.get_update_info_by_app_version
+CREATE OR REPLACE FUNCTION get_update_info_by_app_version (
+    app_platform   platforms,
+    app_version text,
+    bundle_id  uuid,
+    min_bundle_id uuid,
+    target_channel text,
+    target_app_version_list text[]
+)
+RETURNS TABLE (
+    id            uuid,
+    should_force_update  boolean,
+    message       text,
+    status        text,
+    storage_uri   text,
+    file_hash     text
+)
+LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    NIL_UUID CONSTANT uuid := '00000000-0000-0000-0000-000000000000';
+BEGIN
+    RETURN QUERY
+    WITH update_candidate AS (
+        SELECT
+            b.id,
+            b.should_force_update,
+            b.message,
+            'UPDATE' AS status,
+            b.storage_uri,
+            b.file_hash
+        FROM bundles b
+        WHERE b.enabled = TRUE
+          AND b.platform = app_platform
+          AND b.origin_bundle_id > bundle_id
+          AND b.origin_bundle_id > min_bundle_id
+          AND b.target_app_version IN (SELECT unnest(target_app_version_list))
+          AND b.channel = target_channel
+        ORDER BY b.origin_bundle_id DESC
+        LIMIT 1
+    ),
+    rollback_candidate AS (
+        SELECT
+            b.id,
+            TRUE AS should_force_update,
+            b.message,
+            'ROLLBACK' AS status,
+            b.storage_uri,
+            b.file_hash
+        FROM bundles b
+        WHERE b.enabled = TRUE
+          AND b.platform = app_platform
+          AND b.origin_bundle_id < bundle_id
+          AND b.origin_bundle_id > min_bundle_id
+        ORDER BY b.origin_bundle_id DESC
+        LIMIT 1
+    ),
+    final_result AS (
+        SELECT * FROM update_candidate
+        UNION ALL
+        SELECT * FROM rollback_candidate
+        WHERE NOT EXISTS (SELECT 1 FROM update_candidate)
+    )
+    SELECT *
+    FROM final_result
+
+    UNION ALL
+
+    SELECT
+        NIL_UUID      AS id,
+        TRUE          AS should_force_update,
+        NULL          AS message,
+        'ROLLBACK'    AS status,
+        NULL          AS storage_uri,
+        NULL          AS file_hash
+    WHERE (SELECT COUNT(*) FROM final_result) = 0
+      AND bundle_id != NIL_UUID
+      AND bundle_id > min_bundle_id
+      AND NOT EXISTS (
+          SELECT 1
+          FROM bundles b
+          WHERE b.origin_bundle_id = bundle_id
+            AND b.enabled = TRUE
+            AND b.platform = app_platform
+      );
+END;
+$$;


### PR DESCRIPTION
## Summary

- Add `originBundleId` field to Bundle type to track original deployed bundle identity across copy-promotions
- All version ordering/comparison logic now uses `originBundleId` instead of `id`, treating copy-promoted bundles as bundles from their original build time
- Fixes infinite update loop caused by copy-promoted bundles (gronxb/hot-updater#865)

## Changes across all backends

- **Core**: `originBundleId` field added to Bundle type
- **JS (AWS/Firebase shared)**: `originBundleId`-based candidate selection and ordering
- **Cloudflare D1**: SQL CTEs use `origin_bundle_id` for comparisons and ordering
- **PostgreSQL/Supabase**: stored procedures updated with `origin_bundle_id` ordering
- **ORM (fumadb)**: `originBundleId`-based sorting with backward compat via `getOriginBundleId()` helper
- **Firebase**: Firestore queries switched to `origin_bundle_id` ordering (also fixes the `limit(1)` post-filter bug)
- **Console**: propagate `originBundleId` on copy-promotion
- **Schema**: new `v0_27_0` schema with `origin_bundle_id` column
- **Migrations**: D1 and Supabase migrations with backfill from `storageUri`

## Design rationale

Copy-promoted bundles reuse the same physical JS bundle file with `__HOT_UPDATER_BUNDLE_ID` hardcoded at build time. Since UUIDv7 encodes creation time and the library uses UUID comparison for version ordering, a copy-promoted bundle should be treated as a bundle from its original build time — not its promotion time.

Ref: gronxb/hot-updater#865